### PR TITLE
Fixed improper data type (was int, now short)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -89,7 +89,7 @@ class App extends Component {
   doOutput(ench, lvls) {
     const zipped = zip(ench, lvls);
     const result = zipped.map(en => {
-      return `{id:${en[0]},lvl:${en[1]}}`
+      return `{id:${en[0]}s,lvl:${en[1]}s}`
     });
     return result.join(',');
   }


### PR DESCRIPTION
`id:5,lvl:5` writes two ints to NBT, however they should be shorts (`id:5s,lvl:5s`).

The enchantment will still work with either one, but using ints has the following disadvantages:
* data storage wasted
* incompatible with vanilla enchantments
  * consider a command such as `testfor @a {SelectedItem:{ench:[{id:0s}]}}`
  * it succeeds with a vanilla-enchanted protection item, but fails with this generator currently